### PR TITLE
chore: added flow to apply design tokens in app using DS helper method 

### DIFF
--- a/client/web/src/main/main.ts
+++ b/client/web/src/main/main.ts
@@ -1,7 +1,7 @@
 import {Connect, ConnectConfig, defaultConnectConfig} from '@genesislcap/foundation-comms';
 import {Navigation} from '@genesislcap/foundation-header';
 import {baseLayerLuminance, StandardLuminance} from '@microsoft/fast-components';
-import {FASTElement, customElement, observable} from '@microsoft/fast-element';
+import {FASTElement, customElement, observable, DOM} from '@microsoft/fast-element';
 import {Container, inject, Registration} from '@microsoft/fast-foundation';
 import {DefaultRouteRecognizer} from '@microsoft/fast-router';
 import {DynamicTemplate as template, LoadingTemplate, MainTemplate} from './main.template';
@@ -9,6 +9,8 @@ import {MainStyles as styles} from './main.styles';
 import {MainRouterConfig} from '../routes';
 import * as Components from '../components';
 import {logger} from '../utils';
+import designTokens from '../styles/design-tokens.json';
+import { configureDesignSystem } from '@genesislcap/foundation-ui';
 
 const name = 'blank-app';
 
@@ -36,6 +38,9 @@ export class MainApplication extends FASTElement {
     super.connectedCallback();
 
     logger.debug(`${name} is now connected to the DOM`);
+    DOM.queueUpdate(() => {
+      configureDesignSystem(this.provider, designTokens);
+    });
 
     this.registerDIDependencies();
     await this.loadRemotes();

--- a/client/web/src/styles/design-tokens.json
+++ b/client/web/src/styles/design-tokens.json
@@ -1,0 +1,57 @@
+{
+   "design_tokens": {
+     "color": {
+       "accent": {
+         "$value": "#0EAFE2",
+         "$type": "color"
+       },
+       "neutral": {
+         "$value": "#7C909B",
+         "$type": "color"
+       }
+     },
+     "fontFamily": {
+       "bodyFont": {
+         "$value": "Roboto, \"Segoe UI\", Arial, Helvetica, sans-serif",
+         "$type": "fontFamily"
+       }
+     },
+     "typography": {
+       "baseFontSize": {
+         "$value": "14px",
+         "$type": "dimension"
+       },
+       "baseLineHeight": {
+         "$value": "20px",
+         "$type": "dimension"
+       }
+     },
+     "mode": {
+       "luminance": {
+         "$value": 0.23,
+         "$type": "number"
+       }
+     },
+     "style": {
+       "density": {
+         "$value": 0,
+         "$type": "number"
+       },
+       "borderRadius": {
+         "$value": 4,
+         "$type": "number"
+       },
+       "strokeWidth": {
+         "$value": 1,
+         "$type": "number"
+       }
+     },
+     "space": {
+       "designUnit": {
+         "$value": 4,
+         "$type": "number"
+       }
+     }
+   }
+ }
+ 


### PR DESCRIPTION
🤔   **What does this PR do?**
- imports configureDesignSystem and calls it in main.ts
- adds a new file 'design-tokens.json' in client/web/src/styles where generated values from DSC preview are pasted into

 **How should this be tested?**
```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run dev` to run the app
4. Go to `https://learn.genesis.global/docs/web/design-systems/preview/` and click on `Launch DSC` button. This will launch DSC app in a separate window.
5. Make changes in the design tokens i.e. accent-color, neutral color, font etc and click on save button
6. Copy the design tokens from the modal launches on clicking save
7. Paste these tokens in client/web/src/styles/design-tokens.json file
8. Refresh the app from step 3 to see the changes you have made in DSC app 
```
** Samples **
- Demo video
[PTL-1019.webm](https://github.com/genesiscommunitysuccess/webtraining-alpha/assets/118179643/a4a8787f-cdef-470e-9a5a-e220e293fbc9)

